### PR TITLE
Allow graceful stop of HTTP server with Context cancellation

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -14,7 +14,7 @@ func main() {
 		Handler: http.HandlerFunc(hello),
 	}
 
-	if err := graceful.Shutdown(srv, 10*time.Second); err != nil {
+	if err := graceful.Start(srv, 10*time.Second); err != nil {
 		log.Println(err)
 	}
 }

--- a/graceful.go
+++ b/graceful.go
@@ -9,15 +9,51 @@ import (
 	"time"
 )
 
-// Shutdown gracefully stops the given HTTP server on
-// receiving a stop signal and waits for the active connections
-// to be closed for {timeout} period of time.
-func Shutdown(srv *http.Server, timeout time.Duration) error {
+// Start the given HTTP server and wait for receiving
+// a stop signal to gracefully stop it by waiting for
+// {timeout} period of time to complete its current
+// in-flight requests.
+func Start(srv *http.Server, timeout time.Duration) error {
 	done := make(chan error, 1)
 	go func() {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 		<-c
+
+		ctx := context.Background()
+		var cancel context.CancelFunc
+		if timeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+
+		done <- srv.Shutdown(ctx)
+	}()
+
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+
+	return <-done
+}
+
+// StartCtx start the given HTTP server and wait for receiving
+// a stop signal or context cancellation signal to gracefully stop
+// it by waiting for {timeout} period of time to complete its current
+// in-flight requests.
+//
+// The {timeout} period is always respected.
+func StartCtx(ctx context.Context, srv *http.Server, timeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+		// wait for a signal or context cancellation
+		select {
+		case <-c:
+		case <-ctx.Done():
+		}
 
 		ctx := context.Background()
 		var cancel context.CancelFunc

--- a/graceful_test.go
+++ b/graceful_test.go
@@ -1,6 +1,7 @@
 package graceful_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"os"
@@ -21,7 +22,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	time.Sleep(h.requestTime)
 }
 
-func TestShutdown(t *testing.T) {
+func TestStart(t *testing.T) {
 	tests := []struct {
 		// input
 		name    string
@@ -71,7 +72,7 @@ func TestShutdown(t *testing.T) {
 
 			reqerr := make(chan error, 1)
 			go func() {
-				if err := graceful.Shutdown(srv, test.timeout); err != nil {
+				if err := graceful.Start(srv, test.timeout); err != nil {
 					reqerr <- err
 				}
 			}()
@@ -99,6 +100,84 @@ func TestShutdown(t *testing.T) {
 			}
 
 			assert.True(t, time.Now().Sub(start) < test.maxShutdownDuration)
+		})
+	}
+}
+
+func TestStartWithContext(t *testing.T) {
+	tests := []struct {
+		// input
+		name           string
+		contextTimeout time.Duration
+		addr           string
+		timeout        time.Duration
+		reqTime        time.Duration
+
+		// desired outcome
+		err                 error
+		maxShutdownDuration time.Duration
+	}{
+		{
+			name:           "with context timeout higher than request processing time",
+			addr:           ":58431",
+			contextTimeout: 500 * time.Millisecond,
+			reqTime:        200 * time.Millisecond,
+
+			err:                 nil,
+			maxShutdownDuration: 250 * time.Millisecond,
+		},
+		{
+			name:           "context timeout lower than request processing time",
+			addr:           ":58432",
+			timeout:        10 * time.Millisecond,
+			contextTimeout: 100 * time.Millisecond,
+			reqTime:        300 * time.Millisecond,
+
+			err:                 errors.New("context deadline exceeded"),
+			maxShutdownDuration: 150 * time.Millisecond,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := &http.Server{
+				Addr:    test.addr,
+				Handler: &handler{requestTime: test.reqTime},
+			}
+
+			ctx := context.Background()
+			var cancel context.CancelFunc
+			if test.contextTimeout > 0 {
+				ctx, cancel = context.WithTimeout(ctx, test.contextTimeout)
+				defer cancel()
+			}
+
+			reqerr := make(chan error, 1)
+			go func() {
+				if err := graceful.StartCtx(ctx, srv, test.timeout); err != nil {
+					reqerr <- err
+				}
+			}()
+
+			go func() {
+				_, err := http.Get("http://localhost" + test.addr)
+				reqerr <- err
+			}()
+
+			start := time.Now()
+
+			// wait a while so the HTTP request could be sent
+			time.Sleep(50 * time.Millisecond)
+
+			err := <-reqerr
+
+			if test.err != nil {
+				assert.EqualError(t, err, test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.True(t, time.Since(start) < test.maxShutdownDuration)
 		})
 	}
 }


### PR DESCRIPTION
Support cancellation either through os.Signal or
Context cancellation event. The API was changed from
`Shutdown` to `Start` to make it clear that these
functions start the server while supporting it to
stop gracefully.